### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/app/src/main/java/com/ozj/baby/event/EventConstant.java
+++ b/app/src/main/java/com/ozj/baby/event/EventConstant.java
@@ -9,10 +9,13 @@ import java.util.List;
 /**
  * Created by Administrator on 2016/6/5.
  */
-public class EventConstant {
+public final class EventConstant {
     public final static int REFRESH = 0;
     public final static int LOADMORE = 1;
     public final static int DELETE = 2;
     public final static int ADD = 4;
 
+    private EventConstant() throws InstantiationException {
+        throw new InstantiationException("This utility class is not created for instatiation");
+    }
 }

--- a/app/src/main/java/com/ozj/baby/util/SchedulersCompat.java
+++ b/app/src/main/java/com/ozj/baby/util/SchedulersCompat.java
@@ -11,7 +11,11 @@ import rx.schedulers.Schedulers;
  * RxjavaScheduler线程与Main线程切换
  */
 @SuppressWarnings("unchecked")
-public class SchedulersCompat {
+public final class SchedulersCompat {
+
+    private SchedulersCompat() throws InstantiationException {
+        throw new InstantiationException("This utility class is not created for instantiation");
+    }
 
     private static final Observable.Transformer computationTransformer =
             new Observable.Transformer() {

--- a/easeui/src/main/java/com/hyphenate/easeui/utils/EaseCommonUtils.java
+++ b/easeui/src/main/java/com/hyphenate/easeui/utils/EaseCommonUtils.java
@@ -33,8 +33,14 @@ import com.hyphenate.util.HanziToPinyin.Token;
 import java.util.ArrayList;
 import java.util.List;
 
-public class EaseCommonUtils {
-	private static final String TAG = "CommonUtils";
+public final class EaseCommonUtils {
+
+    private static final String TAG = "CommonUtils";
+
+    private EaseCommonUtils() throws InstantiationException {
+        throw new InstantiationException("This utility class is not created for instantiation");
+    }
+
 	/**
 	 * 检测网络是否可用
 	 * 

--- a/easeui/src/main/java/com/hyphenate/easeui/utils/EaseSmileUtils.java
+++ b/easeui/src/main/java/com/hyphenate/easeui/utils/EaseSmileUtils.java
@@ -31,7 +31,7 @@ import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class EaseSmileUtils {
+public final class EaseSmileUtils {
     public static final String DELETE_KEY = "em_delete_delete_expression";
     
 	public static final String EE_1 = "[):]";
@@ -88,6 +88,10 @@ public class EaseSmileUtils {
 	        }
 	    }
 	    
+	}
+
+	private EaseSmileUtils() throws InstantiationException {
+		throw new InstantiationException("This utility class is not created for instantiation");
 	}
 
 	/**

--- a/easeui/src/main/java/com/hyphenate/easeui/utils/EaseUserUtils.java
+++ b/easeui/src/main/java/com/hyphenate/easeui/utils/EaseUserUtils.java
@@ -11,14 +11,18 @@ import com.hyphenate.easeui.controller.EaseUI;
 import com.hyphenate.easeui.controller.EaseUI.EaseUserProfileProvider;
 import com.hyphenate.easeui.domain.EaseUser;
 
-public class EaseUserUtils {
+public final class EaseUserUtils {
     
     static EaseUserProfileProvider userProvider;
     
     static {
         userProvider = EaseUI.getInstance().getUserProfileProvider();
     }
-    
+
+    private EaseUserUtils() throws InstantiationException {
+        throw new InstantiationException("This utility class is not created for instantiation");
+    }
+
     /**
      * 根据username获取相应user
      * @param username


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat